### PR TITLE
AI상담기능 -> 오늘의 식단 추천으로 변경

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -17,7 +17,7 @@
                             프로필
                         </NuxtLink>
                         <NuxtLink to="/ai" class="text-primary hover:underline">
-                            AI 상담
+                            오늘의 식단
                         </NuxtLink>
                         <NuxtLink
                             to="/mypage"
@@ -52,7 +52,7 @@
 
                     <ThemeToggle />
                 </div>
-                <div class="flex items-center block sm:hidden">
+                <div class="flex items-center sm:hidden">
                     <UButton
                         @click="toggleMenu"
                         icon="i-heroicons-bars-4"
@@ -87,7 +87,7 @@
                         color="white"
                         variant="link"
                         class="w-full min-h-16 block"
-                        >AI상담</UButton
+                        >오늘의 식단</UButton
                     >
                 </NuxtLink>
                 <NuxtLink to="/mypage">

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,6 +1,7 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
     devtools: { enabled: true },
+
     runtimeConfig: {
         public: {
             origin: process.env.VUE_APP_ORIGIN,
@@ -31,4 +32,5 @@ export default defineNuxtConfig({
     },
 
     css: ["~/assets/css/main.css", "@/assets/css/global.css"],
+    compatibilityDate: "2025-03-20",
 });

--- a/pages/ai/index.vue
+++ b/pages/ai/index.vue
@@ -359,9 +359,27 @@ const getResult = async () => {
     }
 };
 
-const clearResult = () => {
-    textArea.value = "";
-    generateResult.value = null;
+const clearResult = async () => {
+    resultDiet.value = null;
+    resultWorkout.value = null;
+
+    checkedItems.value = [];
+
+    if (resultId.value != null) {
+        const result: APIResponse<null> = await $fetch("/diet/log", {
+            baseURL: config.public.apiBase,
+            method: "DELETE",
+            headers: {
+                Authorization: `Bearer ${authStore.accessToken}`,
+            },
+            body: {
+                date: new Date().toISOString().split("T")[0],
+                resultId: resultId.value ?? null,
+            },
+        });
+
+        resultId.value = null;
+    }
 };
 
 const goLogin = () => {

--- a/pages/ai/index.vue
+++ b/pages/ai/index.vue
@@ -240,6 +240,17 @@ onMounted(() => {
 
         navigateTo("/profile");
     }
+
+    if (route.query.token != null) {
+        getProfileByToken();
+        return;
+    }
+
+    if (authStore.userProfile != null) {
+        userProfile.value = authStore.userProfile;
+
+        getUserDiet();
+    }
 });
 
 onBeforeUnmount(() => {

--- a/pages/ai/index.vue
+++ b/pages/ai/index.vue
@@ -51,15 +51,72 @@
             </template>
 
             <!-- 결과 -->
-            <template v-if="!loading && generateResult != null">
-                <div class="mb-8" v-html="generateResult" />
+            <template
+                v-if="!loading && resultDiet != null && resultWorkout != null"
+            >
+                <!-- 식단 추천 -->
+                <div class="mb-6">
+                    <div class="text-xl font-semibold mb-4">
+                        🍽 오늘의 식단 추천
+                    </div>
+
+                    <div class="grid gap-4 md:grid-cols-3">
+                        <div
+                            v-for="(item, index) in resultDiet"
+                            :key="'result-' + index"
+                            :class="[
+                                'border border-gray-200 rounded-xl p-4 shadow-sm',
+                                item.checked ? 'bg-green-50' : 'bg-white',
+                            ]"
+                        >
+                            <div class="font-bold text-gray-700 text-base mb-2">
+                                {{ item.meal }}
+                            </div>
+                            <ul class="text-sm text-gray-700 space-y-1">
+                                <li>칼로리: {{ item.calories }} kcal</li>
+                                <li>탄수화물: {{ item.carbs }}g</li>
+                                <li>단백질: {{ item.protein }}g</li>
+                                <li>지방: {{ item.fat }}g</li>
+                            </ul>
+                            <UCheckbox
+                                v-if="isLogin()"
+                                v-model="item.checked"
+                                @change="onDietCheck(item, index)"
+                                class="mt-2"
+                            />
+                        </div>
+                    </div>
+                </div>
+
+                <!-- 운동 추천 -->
+                <div class="mb-8">
+                    <div class="text-xl font-semibold mb-4">
+                        💪 오늘의 운동 추천
+                    </div>
+                    <ul
+                        class="list-disc pl-6 text-gray-800 border border-gray-200 rounded-xl p-4 shadow-sm bg-white"
+                    >
+                        <li
+                            v-for="(workout, idx) in resultWorkout"
+                            :key="'workout-' + idx"
+                        >
+                            {{ workout }}
+                        </li>
+                    </ul>
+                </div>
                 <div class="flex gap-4 mb-8">
+                    <!-- <UButton
+                        class="bg-second text-primary-foreground hover:bg-second/90"
+                    >
+                        저장하기
+                    </UButton> -->
                     <UButton
                         @click="clearResult"
                         class="bg-second text-primary-foreground hover:bg-second/90"
                     >
                         다시하기
                     </UButton>
+
                     <UButton
                         v-if="!isLogin()"
                         @click="goLogin()"

--- a/pages/ai/index.vue
+++ b/pages/ai/index.vue
@@ -1,30 +1,48 @@
 <template>
     <UContainer class="max-w-screen-lg">
-        <h2 class="text-3xl font-bold my-6">AI 상담</h2>
+        <h2 class="text-3xl font-bold my-6">오늘의 식단 추천</h2>
         <UCard>
             <!-- 제목 -->
-            <div class="text-2xl font-bold mb-4">CaloMate AI와 상담하기</div>
+            <div class="text-2xl font-bold mb-4">
+                CaloMate AI 에게 추천 받기
+            </div>
 
             <!-- 상담 입력폼 -->
-            <template v-if="!loading && generateResult == null">
-                <UTextarea
-                    v-model="textArea"
-                    class="mb-4"
-                    placeholder="상담받을 내용을 입력해주세요"
-                />
+            <template
+                v-if="!loading && resultDiet == null && resultWorkout == null"
+            >
+                <!-- 현재 프로필 정보 -->
+                <template v-if="userProfile != null">
+                    <div class="text-xl font-semibold mb-2">
+                        현재 프로필 정보
+                    </div>
+
+                    <ul class="text-sm space-y-1 mb-4">
+                        <li>나이: {{ userProfile.age }}</li>
+                        <li>
+                            성별:
+                            {{ getGenderText() }}
+                        </li>
+                        <li>키: {{ userProfile.height }} cm</li>
+                        <li>몸무게: {{ userProfile.weight }} kg</li>
+                        <li>활동 수준: {{ getActivityText() }}</li>
+                        <li>목표: {{ getTargetText() }}</li>
+                    </ul>
+                </template>
+
                 <UButton
-                    @click="sendText()"
+                    @click="getResult()"
                     :loading="loading"
                     class="bg-second text-primary-foreground hover:bg-second/90"
                 >
-                    전송
+                    추천 받기
                 </UButton>
 
                 <div
                     v-if="authStore.accessToken != null"
                     class="mt-2 opacity-50"
                 >
-                    - 상담 내역은 마이페이지에서 확인할 수 있습니다.
+                    - 추천 내역은 마이페이지에서 확인할 수 있습니다.
                 </div>
 
                 <div v-else class="mt-2 opacity-50">

--- a/pages/mypage/index.vue
+++ b/pages/mypage/index.vue
@@ -1,15 +1,34 @@
 <template>
     <UContainer class="max-w-screen-lg">
         <UCard class="my-16">
-            <el-menu
-                :default-active="activeIndex"
-                class="el-menu !bg-transparent my-2"
-                mode="horizontal"
-                @select="selectMenu"
+            <!-- TabsList -->
+            <div
+                class="grid grid-cols-2 w-full mb-4 border rounded-xl overflow-hidden"
             >
-                <el-menu-item index="1"> 몸무게 추세 </el-menu-item>
-                <el-menu-item index="2"> 이전 상담 내역 </el-menu-item>
-            </el-menu>
+                <button
+                    :class="[
+                        'px-4 py-2 text-center text-sm font-medium transition-colors',
+                        activeIndex === '1'
+                            ? 'bg-second text-primary-foreground'
+                            : 'text-primary',
+                    ]"
+                    @click="activeIndex = '1'"
+                >
+                    대시 보드
+                </button>
+
+                <button
+                    :class="[
+                        'px-4 py-2 text-center text-sm font-medium transition-colors',
+                        activeIndex === '2'
+                            ? 'bg-second text-primary-foreground'
+                            : 'text-primary',
+                    ]"
+                    @click="activeIndex = '2'"
+                >
+                    이전 추천 내역
+                </button>
+            </div>
             <template v-if="!loading">
                 <template v-if="activeIndex == '1'">
                     <div class="text-2xl font-bold my-4">몸무게 추세</div>

--- a/pages/mypage/index.vue
+++ b/pages/mypage/index.vue
@@ -104,8 +104,51 @@
                                     activeContent != -1 &&
                                     activeContent == index
                                 "
-                                v-html="convertReplacedText(item.content)"
-                            />
+                                class="transition-all"
+                            >
+                                <div class="grid gap-4 md:grid-cols-3">
+                                    <div
+                                        v-for="(i, index) in JSON.parse(
+                                            item.content
+                                        ).diet"
+                                        :key="'result-' + index"
+                                        class="border border-gray-200 rounded-xl p-4 shadow-sm bg-white"
+                                    >
+                                        <div
+                                            class="font-bold text-gray-700 text-base mb-2"
+                                        >
+                                            {{ i.meal }}
+                                        </div>
+                                        <ul
+                                            class="text-sm text-gray-700 space-y-1"
+                                        >
+                                            <li>
+                                                칼로리: {{ i.calories }} kcal
+                                            </li>
+                                            <li>탄수화물: {{ i.carbs }}g</li>
+                                            <li>단백질: {{ i.protein }}g</li>
+                                            <li>지방: {{ i.fat }}g</li>
+                                        </ul>
+                                    </div>
+                                </div>
+                                <div class="mt-8">
+                                    <div class="text-xl font-semibold mb-4">
+                                        운동 추천
+                                    </div>
+                                    <ul
+                                        class="list-disc pl-6 text-gray-800 border border-gray-200 rounded-xl p-4 shadow-sm bg-white"
+                                    >
+                                        <li
+                                            v-for="(workout, idx) in JSON.parse(
+                                                item.content
+                                            ).workout"
+                                            :key="'workout-' + idx"
+                                        >
+                                            {{ workout }}
+                                        </li>
+                                    </ul>
+                                </div>
+                            </div>
                         </UCard>
                     </template>
                 </template>

--- a/pages/mypage/index.vue
+++ b/pages/mypage/index.vue
@@ -70,9 +70,9 @@
                 </template>
 
                 <template v-else>
-                    <div class="text-2xl font-bold my-4">이전 상담 내역</div>
+                    <div class="text-2xl font-bold my-4">이전 추천 내역</div>
                     <div class="my-2 opacity-50">
-                        이전 상담내역은 최근순으로 5개까지 표시됩니다.
+                        추천 내역은 최근순으로 5개까지 표시됩니다.
                     </div>
 
                     <template v-if="historyList.length > 0">

--- a/structure/type.ts
+++ b/structure/type.ts
@@ -70,3 +70,25 @@ export interface LoginData {
 export enum KoreaTimeEnum {
     Day = "day",
 }
+
+export interface Meal {
+    meal: string;
+    calories: number;
+    carbs: number;
+    protein: number;
+    fat: number;
+
+    checked: boolean;
+}
+
+export interface AIResponse {
+    diet: Meal[];
+    workout: string[];
+}
+
+export interface WeekdayStats {
+    date: string;
+    total: number;
+    completed: number;
+    rate: number;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,4 @@
 {
-  // https://nuxt.com/docs/guide/concepts/typescript
-  "extends": "./.nuxt/tsconfig.json"
+    // https://nuxt.com/docs/guide/concepts/typescript
+    "extends": "./.nuxt/tsconfig.json"
 }


### PR DESCRIPTION
이번 PR은 AI상담 기능을 오늘의 식단 추천으로 변경하면서 리메이크 하는 PR입니다.

## 변경사항
### 오늘의 식단 페이지
- AI상담 -> 오늘의 식단 추천으로 변경
- diet, workout으로 결과 분리
- diet체크 로직 추가
- 다시하기 관련 로직 구현 및 API 연결
- 오늘의 식단 추천 페이지에서 유저 프로필 정보 받아오도록 수정
### 마이페이지
- El-menu삭제, TabList구현
- 주간 식단 이행률 Bar차트 추가
- 식단 이행률 정보를 받는 API 주소 연결
- 마이페이지 상담 기록 -> 마이페이지 추천 기록으로 문구 변경
- 마이페이지 추천 기록 오늘의 식단 페이지와 디자인 일치하도록 수정
### type.ts
- AIResponse, Meal등 interface 추가